### PR TITLE
[BUGFIX] Add typecasts and null-coalesce-operators

### DIFF
--- a/Classes/Domain/Validator/RecaptchaValidator.php
+++ b/Classes/Domain/Validator/RecaptchaValidator.php
@@ -148,8 +148,8 @@ class RecaptchaValidator extends AbstractValidator
      */
     protected function getActionName(): string
     {
-        $pluginVariables = $this->request->getQueryParams()['tx_powermail_pi1'];
-        ArrayUtility::mergeRecursiveWithOverrule($pluginVariables, $this->request->getParsedBody()['tx_powermail_pi1']);
+        $pluginVariables = (array) ($this->request->getQueryParams()['tx_powermail_pi1'] ?? []);
+        ArrayUtility::mergeRecursiveWithOverrule($pluginVariables, (array) ($this->request->getParsedBody()['tx_powermail_pi1'] ?? []));
         return $pluginVariables['action'];
     }
 }

--- a/Classes/Domain/Validator/SpamShield/RecaptchaMethod.php
+++ b/Classes/Domain/Validator/SpamShield/RecaptchaMethod.php
@@ -124,8 +124,8 @@ class RecaptchaMethod extends AbstractMethod
     protected function getActionName(): string
     {
         $request = $GLOBALS['TYPO3_REQUEST'];
-        $pluginVariables = $request->getQueryParams()['tx_powermail_pi1'];
-        ArrayUtility::mergeRecursiveWithOverrule($pluginVariables, $request->getParsedBody()['tx_powermail_pi1']);
+        $pluginVariables = (array) ($request->getQueryParams()['tx_powermail_pi1'] ?? []);
+        ArrayUtility::mergeRecursiveWithOverrule($pluginVariables, (array) ($request->getParsedBody()['tx_powermail_pi1'] ?? []));
         return $pluginVariables['action'];
     }
 }


### PR DESCRIPTION
Ensure both parameters are of type array as expected by ArrayUtility::mergeRecursiveWithOverrule().